### PR TITLE
Fixes #17: Remove textgroup selection from import form

### DIFF
--- a/i18n_string/i18n_string.module
+++ b/i18n_string/i18n_string.module
@@ -318,16 +318,14 @@ function i18n_string_form_locale_translate_import_form_alter(&$form, $form_state
       $form['import']['langcode']['#options'][t('Languages not yet added')]['en'] = t('English');
     }
   }
-  // Add textgroup options which got removed from core.
-  // Import by textgroup not working yet, we set a default value.
+  // Import by textgroup is not supported by core anymore, we set a default
+  // value.
   // @see https://github.com/backdrop-contrib/i18n/issues/17
   $form['import']['group'] = array(
-    '#type' => 'radios',
-    '#title' => t('Text group'),
-    '#default_value' => 'default',
-    '#options' => i18n_string_textgroup_options(),
-    '#disabled' => TRUE,
+    '#type' => 'value',
+    '#value' => 'default',
   );
+
   $form['import']['submit']['#weight'] = 1;
   $form['#submit'][] = 'i18n_string_locale_translate_import_form_submit';
 }


### PR DESCRIPTION
Fixes #17, same logic as before, but no more visible form items for textgroup.